### PR TITLE
Replace println calls with log crate macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "futures",
+ "log",
  "mqtt-v5",
  "nanoid",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +88,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -197,6 +230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "libc"
 version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +295,7 @@ name = "mqtt-v5-broker"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "env_logger",
  "futures",
  "log",
  "mqtt-v5",
@@ -528,6 +568,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "serde"
 version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +611,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -647,6 +713,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/mqtt-v5-broker/Cargo.toml
+++ b/mqtt-v5-broker/Cargo.toml
@@ -16,3 +16,4 @@ mqtt-v5 = { path = "../mqtt-v5", version = "0.2" }
 nanoid = "0.3"
 tokio = { version = "1", features = ["net", "rt-multi-thread", "sync", "time", "macros"] }
 tokio-util = { version = "0.6", features = ["codec"] }
+env_logger = "0.8.4"

--- a/mqtt-v5-broker/Cargo.toml
+++ b/mqtt-v5-broker/Cargo.toml
@@ -10,8 +10,9 @@ edition = "2018"
 
 [dependencies]
 bytes = "1"
-tokio = { version = "1", features = ["net", "rt-multi-thread", "sync", "time", "macros"] }
-tokio-util = { version = "0.6", features = ["codec"] }
+futures = "0.3"
+log = "0.4"
 mqtt-v5 = { path = "../mqtt-v5", version = "0.2" }
 nanoid = "0.3"
-futures = "0.3"
+tokio = { version = "1", features = ["net", "rt-multi-thread", "sync", "time", "macros"] }
+tokio-util = { version = "0.6", features = ["codec"] }

--- a/mqtt-v5-broker/src/broker.rs
+++ b/mqtt-v5-broker/src/broker.rs
@@ -1,4 +1,5 @@
 use crate::{client::ClientMessage, tree::SubscriptionTree};
+use log::{info, warn};
 use mqtt_v5::{
     topic::TopicFilter,
     types::{
@@ -155,7 +156,7 @@ impl Session {
     async fn send(&mut self, message: ClientMessage) {
         if let Some(ref client_sender) = self.client_sender {
             if client_sender.send(message).await.is_err() {
-                println!("Failed to send message to client. Dropping sender");
+                warn!("Failed to send message to client. Dropping sender");
                 self.client_sender.take();
             }
         }
@@ -216,7 +217,7 @@ impl Broker {
                 if let Err(e) = client_sender
                     .try_send(ClientMessage::Disconnect(DisconnectReason::SessionTakenOver))
                 {
-                    println!("Failed to send disconnect packet to taken-over session - {:?}", e);
+                    warn!("Failed to send disconnect packet to taken-over session - {:?}", e);
                 }
             }
 
@@ -269,7 +270,7 @@ impl Broker {
             existing_session.resend_packets().await;
         }
 
-        println!(
+        info!(
             "Client ID {} connected (Version: {:?})",
             connect_packet.client_id, connect_packet.protocol_version
         );
@@ -441,7 +442,7 @@ impl Broker {
     }
 
     fn handle_disconnect(&mut self, client_id: String, will_disconnect_logic: WillDisconnectLogic) {
-        println!("Client ID {} disconnected", client_id);
+        info!("Client ID {} disconnected", client_id);
 
         let mut disconnect_will = None;
         let mut session_expiry_duration = None;

--- a/mqtt-v5-broker/src/main.rs
+++ b/mqtt-v5-broker/src/main.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use crate::{
     broker::{Broker, BrokerMessage},
     client::UnconnectedClient,
@@ -196,7 +198,17 @@ async fn websocket_server_loop(broker_tx: Sender<BrokerMessage>) {
     }
 }
 
+fn init_logging() {
+    if env::var("RUST_LOG").is_err() {
+        env_logger::builder().filter(None, log::LevelFilter::Debug).init();
+    } else {
+        env_logger::init();
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+
     // Creating a Runtime does the following:
     // * Spawn a background thread running a Reactor instance.
     // * Start a ThreadPool for executing futures.


### PR DESCRIPTION
Replace the println debug statements with macros from the `log` crate. Add [env-logger](https://crates.io/crates/env_logger) as a dependency and initialize.

Fixes #42 