### PR TITLE
Split crate into lib and bin

### DIFF
--- a/mqtt-v5-broker/Cargo.toml
+++ b/mqtt-v5-broker/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2018"
 
 [dependencies]
 bytes = "1"
+env_logger = "0.8.4"
 futures = "0.3"
 log = "0.4"
 mqtt-v5 = { path = "../mqtt-v5", version = "0.2" }
 nanoid = "0.3"
 tokio = { version = "1", features = ["net", "rt-multi-thread", "sync", "time", "macros"] }
 tokio-util = { version = "0.6", features = ["codec"] }
-env_logger = "0.8.4"

--- a/mqtt-v5-broker/src/broker.rs
+++ b/mqtt-v5-broker/src/broker.rs
@@ -17,7 +17,8 @@ use std::{
 };
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
-pub struct Session {
+struct Session {
+    #[allow(unused)]
     pub protocol_version: ProtocolVersion,
     // pub subscriptions: HashSet<SubscriptionTopic>,
     // pub shared_subscriptions: HashSet<SubscriptionTopic>,

--- a/mqtt-v5-broker/src/broker.rs
+++ b/mqtt-v5-broker/src/broker.rs
@@ -196,6 +196,12 @@ pub struct Broker {
     subscriptions: SubscriptionTree<SessionSubscription>,
 }
 
+impl Default for Broker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Broker {
     pub fn new() -> Self {
         let (sender, receiver) = mpsc::channel(100);

--- a/mqtt-v5-broker/src/client.rs
+++ b/mqtt-v5-broker/src/client.rs
@@ -20,19 +20,38 @@ use tokio::{
 };
 use tokio_util::codec::Framed;
 
+use bytes::BytesMut;
+use mqtt_v5::{
+    encoder,
+    websocket::{
+        codec::{Message, MessageCodec as WsMessageCodec, Opcode},
+        WsUpgraderCodec,
+    },
+};
+
 type PacketResult = Result<Packet, DecodeError>;
 
 /// Timeout when writing to a client sink
 const SINK_SEND_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Process MQTT connect on `stream` and spawn a task for this connection
-pub fn spawn<S: AsyncRead + AsyncWrite + Send + Sync + 'static>(
-    stream: S,
-    broker_tx: Sender<BrokerMessage>,
-) {
+/// TOOD(flxo): Move to dedicated module `io`?
+pub fn spawn<S>(stream: S, broker_tx: Sender<BrokerMessage>)
+where
+    S: AsyncRead + AsyncWrite + Send + Sync + 'static,
+{
+    let (packet_sink, packet_stream) = Framed::new(stream, MqttCodec::new()).split();
+    spawn_framed(packet_stream, packet_sink, broker_tx);
+}
+
+/// TOOD(flxo): Move to dedicated module `io`?
+pub fn spawn_framed<ST, SI>(packet_stream: ST, packet_sink: SI, broker_tx: Sender<BrokerMessage>)
+where
+    ST: Stream<Item = PacketResult> + Unpin + Send + Sync + 'static,
+    SI: Sink<Packet, Error = EncodeError> + Unpin + Send + Sync + 'static,
+{
     task::spawn(async move {
-        let (sink, stream) = Framed::new(stream, MqttCodec::new()).split();
-        let unconnected_client = UnconnectedClient::new(stream, sink, broker_tx);
+        let unconnected_client = UnconnectedClient::new(packet_stream, packet_sink, broker_tx);
         match unconnected_client.handshake().await {
             Ok(client) => client.run().await,
             Err(err) => warn!("Protocol error during connection handshake: {:?}", err),
@@ -40,8 +59,122 @@ pub fn spawn<S: AsyncRead + AsyncWrite + Send + Sync + 'static>(
     });
 }
 
-pub struct UnconnectedClient<ST: Stream<Item = PacketResult>, SI: Sink<Packet, Error = EncodeError>>
+/// TOOD(flxo): Move to dedicated module `io`?
+async fn upgrade_ws_stream<S>(stream: S) -> Framed<S, WsMessageCodec>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
 {
+    let mut upgrade_framed = Framed::new(stream, WsUpgraderCodec::new());
+
+    let upgrade_msg = upgrade_framed.next().await;
+
+    if let Some(Ok(websocket_key)) = upgrade_msg {
+        let _ = upgrade_framed.send(websocket_key).await;
+    }
+
+    let old_parts = upgrade_framed.into_parts();
+    let mut new_parts =
+        Framed::new(old_parts.io, WsMessageCodec::with_masked_encode(false)).into_parts();
+    new_parts.read_buf = old_parts.read_buf;
+    new_parts.write_buf = old_parts.write_buf;
+
+    Framed::from_parts(new_parts)
+}
+
+/// TOOD(flxo): Move to dedicated module `io`?
+pub async fn spawn_websocket<S>(stream: S, broker_tx: Sender<BrokerMessage>)
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+{
+    let ws_framed = upgrade_ws_stream(stream).await;
+
+    let (sink, ws_stream) = ws_framed.split();
+    let sink = sink.with(|packet: Packet| {
+        let mut payload_bytes = BytesMut::new();
+        // TODO(bschwind) - Support MQTTv5 here. With a stateful Framed object we can store
+        //                  the version on a successful Connect decode, but in this code structure
+        //                  we can't pass state from the stream to the sink.
+        encoder::encode_mqtt(&packet, &mut payload_bytes, ProtocolVersion::V311);
+
+        async {
+            let result: Result<Message, EncodeError> = Ok(Message::binary(payload_bytes.freeze()));
+            result
+        }
+    });
+
+    let read_buf = BytesMut::with_capacity(4096);
+
+    let stream = stream::unfold(
+        (ws_stream, read_buf, ProtocolVersion::V311),
+        |(mut ws_stream, mut read_buf, mut protocol_version)| {
+            async move {
+                // Loop until we've built up enough data from the WebSocket stream
+                // to decode a new MQTT packet
+                loop {
+                    // Try to read an MQTT packet from the read buffer
+                    match mqtt_v5::decoder::decode_mqtt(&mut read_buf, protocol_version) {
+                        Ok(Some(packet)) => {
+                            if let Packet::Connect(packet) = &packet {
+                                protocol_version = packet.protocol_version;
+                            }
+
+                            // If we got one, return it
+                            return Some((Ok(packet), (ws_stream, read_buf, protocol_version)));
+                        },
+                        Err(e) => {
+                            // If we had a decode error, propagate the error along the stream
+                            return Some((Err(e), (ws_stream, read_buf, protocol_version)));
+                        },
+                        Ok(None) => {
+                            // Otherwise we need more binary data from the WebSocket stream
+                        },
+                    }
+
+                    let ws_frame = ws_stream.next().await;
+
+                    match ws_frame {
+                        Some(Ok(message)) => {
+                            if message.opcode() == Opcode::Close {
+                                return None;
+                            }
+
+                            if message.opcode() == Opcode::Ping {
+                                trace!("Got a websocket ping");
+                            }
+
+                            if message.opcode() != Opcode::Binary {
+                                // MQTT Control Packets MUST be sent in WebSocket binary data frames
+                                return Some((
+                                    Err(DecodeError::BadTransport),
+                                    (ws_stream, read_buf, protocol_version),
+                                ));
+                            }
+
+                            read_buf.extend_from_slice(&message.into_data());
+                        },
+                        Some(Err(e)) => {
+                            debug!("Error while reading from WebSocket stream: {:?}", e);
+                            // If we had a decode error in the WebSocket layer,
+                            // propagate the it along the stream
+                            return Some((
+                                Err(DecodeError::BadTransport),
+                                (ws_stream, read_buf, protocol_version),
+                            ));
+                        },
+                        None => {
+                            // The WebSocket stream is over, so we are too
+                            return None;
+                        },
+                    }
+                }
+            }
+        },
+    );
+
+    spawn_framed(Box::pin(stream), Box::pin(sink), broker_tx);
+}
+
+struct UnconnectedClient<ST: Stream<Item = PacketResult>, SI: Sink<Packet, Error = EncodeError>> {
     packet_stream: ST,
     packet_sink: SI,
     broker_tx: Sender<BrokerMessage>,

--- a/mqtt-v5-broker/src/lib.rs
+++ b/mqtt-v5-broker/src/lib.rs
@@ -1,0 +1,6 @@
+mod broker;
+mod client;
+mod tree;
+
+pub use broker::{Broker, BrokerMessage};
+pub use client::UnconnectedClient;

--- a/mqtt-v5-broker/src/lib.rs
+++ b/mqtt-v5-broker/src/lib.rs
@@ -1,6 +1,3 @@
-mod broker;
-mod client;
+pub mod broker;
+pub mod client;
 mod tree;
-
-pub use broker::{Broker, BrokerMessage};
-pub use client::UnconnectedClient;

--- a/mqtt-v5-broker/src/main.rs
+++ b/mqtt-v5-broker/src/main.rs
@@ -1,151 +1,22 @@
 use std::{env, io};
 
-use bytes::BytesMut;
-use futures::{future::try_join_all, stream, SinkExt, StreamExt};
-use log::{debug, info, trace, warn};
-use mqtt_v5::{
-    encoder,
-    types::{DecodeError, EncodeError, Packet, ProtocolVersion},
-    websocket::{
-        codec::{Message, MessageCodec as WsMessageCodec, Opcode},
-        WsUpgraderCodec,
-    },
-};
+use futures::future::try_join_all;
+use log::{debug, info};
 use mqtt_v5_broker::{
     broker::{Broker, BrokerMessage},
-    client::{self, UnconnectedClient},
+    client,
 };
-use tokio::{
-    net::{TcpListener, TcpStream},
-    sync::mpsc::Sender,
-    task,
-};
-use tokio_util::codec::Framed;
+use tokio::{net::TcpListener, sync::mpsc::Sender, task};
 
-async fn upgrade_stream(stream: TcpStream) -> Framed<TcpStream, WsMessageCodec> {
-    let mut upgrade_framed = Framed::new(stream, WsUpgraderCodec::new());
+/// Bind tcp address TODO: make this configurable
+const TCP_LISTENER_ADDR: &str = "0.0.0.0:1883";
 
-    let upgrade_msg = upgrade_framed.next().await;
+/// Websocket tcp address TODO: make this configurable
+const WEBSOCKET_TCP_LISTENER_ADDR: &str = "0.0.0.0:8080";
 
-    if let Some(Ok(websocket_key)) = upgrade_msg {
-        let _ = upgrade_framed.send(websocket_key).await;
-    }
-
-    let old_parts = upgrade_framed.into_parts();
-    let mut new_parts =
-        Framed::new(old_parts.io, WsMessageCodec::with_masked_encode(false)).into_parts();
-    new_parts.read_buf = old_parts.read_buf;
-    new_parts.write_buf = old_parts.write_buf;
-
-    Framed::from_parts(new_parts)
-}
-
-async fn websocket_client_handler(stream: TcpStream, broker_tx: Sender<BrokerMessage>) {
-    debug!("Handling WebSocket client {:?}", stream.peer_addr());
-
-    let ws_framed = upgrade_stream(stream).await;
-
-    let (sink, ws_stream) = ws_framed.split();
-    let sink = sink.with(|packet: Packet| {
-        let mut payload_bytes = BytesMut::new();
-        // TODO(bschwind) - Support MQTTv5 here. With a stateful Framed object we can store
-        //                  the version on a successful Connect decode, but in this code structure
-        //                  we can't pass state from the stream to the sink.
-        encoder::encode_mqtt(&packet, &mut payload_bytes, ProtocolVersion::V311);
-
-        async {
-            let result: Result<Message, EncodeError> = Ok(Message::binary(payload_bytes.freeze()));
-            result
-        }
-    });
-
-    let read_buf = BytesMut::with_capacity(4096);
-
-    let stream = stream::unfold(
-        (ws_stream, read_buf, ProtocolVersion::V311),
-        |(mut ws_stream, mut read_buf, mut protocol_version)| {
-            async move {
-                // Loop until we've built up enough data from the WebSocket stream
-                // to decode a new MQTT packet
-                loop {
-                    // Try to read an MQTT packet from the read buffer
-                    match mqtt_v5::decoder::decode_mqtt(&mut read_buf, protocol_version) {
-                        Ok(Some(packet)) => {
-                            if let Packet::Connect(packet) = &packet {
-                                protocol_version = packet.protocol_version;
-                            }
-
-                            // If we got one, return it
-                            return Some((Ok(packet), (ws_stream, read_buf, protocol_version)));
-                        },
-                        Err(e) => {
-                            // If we had a decode error, propagate the error along the stream
-                            return Some((Err(e), (ws_stream, read_buf, protocol_version)));
-                        },
-                        Ok(None) => {
-                            // Otherwise we need more binary data from the WebSocket stream
-                        },
-                    }
-
-                    let ws_frame = ws_stream.next().await;
-
-                    match ws_frame {
-                        Some(Ok(message)) => {
-                            if message.opcode() == Opcode::Close {
-                                return None;
-                            }
-
-                            if message.opcode() == Opcode::Ping {
-                                trace!("Got a websocket ping");
-                            }
-
-                            if message.opcode() != Opcode::Binary {
-                                // MQTT Control Packets MUST be sent in WebSocket binary data frames
-                                return Some((
-                                    Err(DecodeError::BadTransport),
-                                    (ws_stream, read_buf, protocol_version),
-                                ));
-                            }
-
-                            read_buf.extend_from_slice(&message.into_data());
-                        },
-                        Some(Err(e)) => {
-                            debug!("Error while reading from WebSocket stream: {:?}", e);
-                            // If we had a decode error in the WebSocket layer,
-                            // propagate the it along the stream
-                            return Some((
-                                Err(DecodeError::BadTransport),
-                                (ws_stream, read_buf, protocol_version),
-                            ));
-                        },
-                        None => {
-                            // The WebSocket stream is over, so we are too
-                            return None;
-                        },
-                    }
-                }
-            }
-        },
-    );
-
-    tokio::pin!(stream);
-    let unconnected_client = UnconnectedClient::new(stream, sink, broker_tx);
-
-    let connected_client = match unconnected_client.handshake().await {
-        Ok(connected_client) => connected_client,
-        Err(err) => {
-            warn!("Protocol error during connection handshake: {:?}", err);
-            return;
-        },
-    };
-
-    connected_client.run().await;
-}
-
-async fn server_loop(broker_tx: Sender<BrokerMessage>) -> io::Result<()> {
-    let bind_addr = "0.0.0.0:1883";
-    info!("Listening on {}", bind_addr);
-    let listener = TcpListener::bind(bind_addr).await?;
+async fn tcp_server_loop(broker_tx: Sender<BrokerMessage>) -> io::Result<()> {
+    info!("Listening on {}", TCP_LISTENER_ADDR);
+    let listener = TcpListener::bind(TCP_LISTENER_ADDR).await?;
 
     loop {
         let (stream, addr) = listener.accept().await?;
@@ -155,15 +26,13 @@ async fn server_loop(broker_tx: Sender<BrokerMessage>) -> io::Result<()> {
 }
 
 async fn websocket_server_loop(broker_tx: Sender<BrokerMessage>) -> io::Result<()> {
-    let bind_addr = "0.0.0.0:8080";
-    info!("Listening on {}", bind_addr);
-    let listener = TcpListener::bind(bind_addr).await?;
+    info!("Listening on {}", WEBSOCKET_TCP_LISTENER_ADDR);
+    let listener = TcpListener::bind(WEBSOCKET_TCP_LISTENER_ADDR).await?;
 
     loop {
         let (socket, addr) = listener.accept().await?;
         debug!("Client {} connected (websocket)", addr);
-
-        websocket_client_handler(socket, broker_tx.clone()).await;
+        client::spawn_websocket(socket, broker_tx.clone()).await;
     }
 }
 
@@ -186,10 +55,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
     });
 
-    let listener = task::spawn(server_loop(broker_tx.clone()));
+    let tcp_listener = task::spawn(tcp_server_loop(broker_tx.clone()));
     let websocket_listener = task::spawn(websocket_server_loop(broker_tx));
 
-    try_join_all([broker, listener, websocket_listener]).await?;
+    try_join_all([broker, tcp_listener, websocket_listener]).await?;
 
     Ok(())
 }

--- a/mqtt-v5-broker/src/main.rs
+++ b/mqtt-v5-broker/src/main.rs
@@ -1,9 +1,5 @@
 use std::env;
 
-use crate::{
-    broker::{Broker, BrokerMessage},
-    client::UnconnectedClient,
-};
 use bytes::BytesMut;
 use futures::{stream, SinkExt, StreamExt};
 use log::{debug, info, trace, warn};
@@ -16,16 +12,13 @@ use mqtt_v5::{
         WsUpgraderCodec,
     },
 };
+use mqtt_v5_broker::{Broker, BrokerMessage, UnconnectedClient};
 use tokio::{
     net::{TcpListener, TcpStream},
     runtime::Runtime,
     sync::mpsc::Sender,
 };
 use tokio_util::codec::Framed;
-
-mod broker;
-mod client;
-mod tree;
 
 async fn client_handler(stream: TcpStream, broker_tx: Sender<BrokerMessage>) {
     debug!("Handling client {:?}", stream.peer_addr());


### PR DESCRIPTION
In order to use the broker with a custom setup (eg. logging, listeners etc), split the crate into a lib and bin. This patchset basically just moves the client accpet/handshake handling into the `client` module.

@bschwind Should `client::spawn_*` be moved to a dedicated module? e.g `client::io`

Fixes #44