### PR TITLE
Scetch a possiblity for custom logic in the broker

### DIFF
--- a/mqtt-v5-broker/src/broker.rs
+++ b/mqtt-v5-broker/src/broker.rs
@@ -638,6 +638,8 @@ impl<A: Plugin> Broker<A> {
     fn handle_disconnect(&mut self, client_id: String, will_disconnect_logic: WillDisconnectLogic) {
         info!("Client ID {} disconnected", client_id);
 
+        self.plugin.on_disconnect(&client_id);
+
         let mut disconnect_will = None;
         let mut session_expiry_duration = None;
 

--- a/mqtt-v5-broker/src/broker.rs
+++ b/mqtt-v5-broker/src/broker.rs
@@ -205,7 +205,7 @@ pub enum WillDisconnectLogic {
 }
 
 /// Unique identifier for a connection
-pub type ConnectionId = String;
+pub type ConnectionId = u64;
 
 /// Client ID
 pub type ClientId = String;
@@ -1014,8 +1014,8 @@ impl<A: Plugin> Broker<A> {
                 BrokerMessage::Subscribe(connection_id, client_id, packet) => {
                     self.handle_subscribe(connection_id, client_id, packet).await;
                 },
-                BrokerMessage::Unsubscribe(conneciton_id, client_id, packet) => {
-                    self.handle_unsubscribe(conneciton_id, client_id, packet).await;
+                BrokerMessage::Unsubscribe(connection_id, client_id, packet) => {
+                    self.handle_unsubscribe(connection_id, client_id, packet).await;
                 },
                 BrokerMessage::Publish(connection_id, client_id, packet) => {
                     self.handle_publish(connection_id, client_id, *packet).await;
@@ -1078,10 +1078,8 @@ mod tests {
             password: Some("test".into()),
         };
 
-        let connection_id = nanoid::nanoid!();
-
         let _ = broker_tx
-            .send(BrokerMessage::Connect(connection_id, Box::new(connect_packet), sender))
+            .send(BrokerMessage::Connect(0, Box::new(connect_packet), sender))
             .await
             .unwrap();
 
@@ -1115,7 +1113,7 @@ mod tests {
 
         let _ = broker_tx
             .send(BrokerMessage::Subscribe(
-                "CONNECTION".to_string(),
+                0,
                 "TEST".to_string(),
                 SubscribePacket {
                     packet_id: 0,

--- a/mqtt-v5-broker/src/client.rs
+++ b/mqtt-v5-broker/src/client.rs
@@ -403,6 +403,12 @@ impl<ST: Stream<Item = PacketResult> + Unpin, SI: Sink<Packet, Error = EncodeErr
 
                             return;
                         },
+                        Packet::Authenticate(packet) => {
+                            broker_tx
+                                .send(BrokerMessage::Authenticate(client_id.clone(), packet))
+                                .await
+                                .expect("Couldn't send Authentivate message to self");
+                        },
                         _ => {},
                     },
                     Err(err) => {

--- a/mqtt-v5-broker/src/lib.rs
+++ b/mqtt-v5-broker/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod broker;
 pub mod client;
+pub mod plugin;
 mod tree;

--- a/mqtt-v5-broker/src/main.rs
+++ b/mqtt-v5-broker/src/main.rs
@@ -1,10 +1,15 @@
 use std::{env, io};
 
 use futures::future::try_join_all;
-use log::{debug, info};
+use log::{debug, info, trace};
+use mqtt_v5::types::{
+    properties::{AuthenticationData, AuthenticationMethod},
+    AuthenticatePacket, PublishPacket, SubscribePacket,
+};
 use mqtt_v5_broker::{
     broker::{Broker, BrokerMessage},
     client,
+    plugin::{self},
 };
 use tokio::{net::TcpListener, sync::mpsc::Sender, task};
 
@@ -44,11 +49,39 @@ fn init_logging() {
     }
 }
 
+#[derive(Default)]
+struct TracePlugin;
+
+impl plugin::Plugin for TracePlugin {
+    fn on_connect(
+        &mut self,
+        _: Option<&AuthenticationMethod>,
+        _: Option<&AuthenticationData>,
+    ) -> plugin::AuthentificationResult {
+        plugin::AuthentificationResult::Success
+    }
+
+    fn on_authenticate(&mut self, packet: &AuthenticatePacket) -> plugin::AuthentificationResult {
+        trace!("Authenticate packet received: {:?}", packet);
+        plugin::AuthentificationResult::Success
+    }
+
+    fn on_subscribe(&mut self, packet: &SubscribePacket) -> plugin::SubscribeResult {
+        trace!("Subscribe packet received: {:?}", packet);
+        plugin::SubscribeResult::Placeholder
+    }
+
+    fn on_publish_received(&mut self, packet: &PublishPacket) -> plugin::PublishReceivedResult {
+        trace!("Publish packet received: {:?}", packet);
+        plugin::PublishReceivedResult::Placeholder
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_logging();
 
-    let broker = Broker::new();
+    let broker = Broker::with_plugin(TracePlugin::default());
     let broker_tx = broker.sender();
     let broker = task::spawn(async {
         broker.run().await;

--- a/mqtt-v5-broker/src/main.rs
+++ b/mqtt-v5-broker/src/main.rs
@@ -49,7 +49,7 @@ fn init_logging() {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_logging();
 
-    let broker = Broker::with_plugin(Noop);
+    let broker = Broker::default();
     let broker_tx = broker.sender();
     let broker = task::spawn(async {
         broker.run().await;

--- a/mqtt-v5-broker/src/main.rs
+++ b/mqtt-v5-broker/src/main.rs
@@ -5,7 +5,6 @@ use log::{debug, info};
 use mqtt_v5_broker::{
     broker::{Broker, BrokerMessage},
     client,
-    plugin::Noop,
 };
 use tokio::{net::TcpListener, sync::mpsc::Sender, task};
 

--- a/mqtt-v5-broker/src/plugin.rs
+++ b/mqtt-v5-broker/src/plugin.rs
@@ -1,0 +1,63 @@
+use mqtt_v5::types::{
+    properties::{AuthenticationData, AuthenticationMethod},
+    *,
+};
+
+pub struct Noop;
+
+/// Result of a authentication attempt
+pub enum AuthentificationResult {
+    /// Authentification is successful.
+    Success,
+    /// Authentification failed. Send connect reason code to the client (ConnectAck)
+    Fail(ConnectReason),
+    /// Send this auth packet to the client and wait for the response.
+    Packet(AuthenticatePacket),
+}
+
+pub enum PublishReceivedResult {
+    Placeholder,
+}
+
+pub enum SubscribeResult {
+    Placeholder,
+}
+
+/// Broker plugin
+pub trait Plugin {
+    /// Called on connect packet reception
+    fn on_connect(
+        &mut self,
+        method: Option<&AuthenticationMethod>,
+        data: Option<&AuthenticationData>,
+    ) -> AuthentificationResult;
+
+    /// Called on authenticate packet reception
+    fn on_authenticate(&mut self, packet: &AuthenticatePacket) -> AuthentificationResult;
+
+    fn on_subscribe(&mut self, packet: &SubscribePacket) -> SubscribeResult;
+    fn on_publish_received(&mut self, packet: &PublishPacket) -> PublishReceivedResult;
+}
+
+/// Default noop authenticator
+impl Plugin for Noop {
+    fn on_connect(
+        &mut self,
+        _: Option<&AuthenticationMethod>,
+        _: Option<&AuthenticationData>,
+    ) -> AuthentificationResult {
+        AuthentificationResult::Success
+    }
+
+    fn on_authenticate(&mut self, _: &AuthenticatePacket) -> AuthentificationResult {
+        AuthentificationResult::Success
+    }
+
+    fn on_subscribe(&mut self, _: &SubscribePacket) -> SubscribeResult {
+        SubscribeResult::Placeholder
+    }
+
+    fn on_publish_received(&mut self, _: &PublishPacket) -> PublishReceivedResult {
+        PublishReceivedResult::Placeholder
+    }
+}

--- a/mqtt-v5-broker/src/plugin.rs
+++ b/mqtt-v5-broker/src/plugin.rs
@@ -20,6 +20,9 @@ pub trait Plugin {
     /// Called on connect packet reception
     fn on_connect(&mut self, packet: &ConnectPacket) -> AuthentificationResult;
 
+    /// Called on client disconnect
+    fn on_disconnect(&mut self, client_id: &str);
+
     /// Called on authenticate packet reception
     fn on_authenticate(&mut self, packet: &AuthenticatePacket) -> AuthentificationResult;
 
@@ -54,6 +57,8 @@ impl Plugin for Noop {
             AuthentificationResult::Reason(ConnectReason::BadUserNameOrPassword)
         }
     }
+
+    fn on_disconnect(&mut self, _: &str) {}
 
     fn on_authenticate(&mut self, _: &AuthenticatePacket) -> AuthentificationResult {
         AuthentificationResult::Reason(ConnectReason::Success)


### PR DESCRIPTION
Use the authentication stuff as an example how customer code could be plugged into the broker. The authentification is not implemented - it's all just about how to proceed...

The concrete type that impls the authentication has the advantage of static dispatch. There ware probably other traits needed for intercepting publishes and subscriptions e.g 

```rust
pub trait {
  async fn on_publish(client_id: &str, publish: &PublishPacket) -> PublicationResult;
  ....
}


Do *not* merge this :-)

